### PR TITLE
browser: Date picker color scheme and typography, Close button label, Da...

### DIFF
--- a/browser/src/app/directives/ssFacetDateRange.js
+++ b/browser/src/app/directives/ssFacetDateRange.js
@@ -53,16 +53,15 @@ define(['app/module'], function (module) {
           '<highchart class="highcharts ss-facet-date-range" ' +
           '  config="highchartsConfig"></highchart>' +
           '<div class="input-daterange input-group">' +
-          '<input ng-model=pickerDateStart type="text" ' +
+          '<input ng-model="pickerDateStart" type="text" ' +
           '  class="input-sm form-control ng-valid-date" ' +
           '  datepicker-popup="MM/dd/yyyy" ' +
           '  datepicker-options="dateStartOptions" ' +
           '  ng-change="applyPickerDates()" ' +
           '  ng-click="pickerOpen(\'dateStartOpened\')" ' +
           '  is-open="dateStartOpened" ' +
-          '  onfocus="this.blur()" ' +
           '  placeholder="{{dateStartPlaceholder}}" ' +
-          '  name="start" />' +
+          '  name="start" close-text="Close" />' +
 
           '<span class="input-group-addon">to</span>' +
 
@@ -73,10 +72,9 @@ define(['app/module'], function (module) {
           '  ng-change="applyPickerDates()"  ' +
           '  ng-click="pickerOpen(\'dateEndOpened\')" ' +
           '  is-open="dateEndOpened" ' +
-          '  onfocus="this.blur()" ' +
           '  placeholder="{{dateEndPlaceholder}}" ' +
           '  class="form-control ng-valid-date"' +
-          '  />' +
+          '  close-text="Close" />' +
           '</div>',
 
         scope: {
@@ -315,7 +313,7 @@ define(['app/module'], function (module) {
               formatYear: 'yy',
               startingDay: 1,
               showWeeks: false,
-              showButtonBar: false
+              showButtonBar: false              
             };
 
             scope.pickerOpen = function (scopeVar) {
@@ -325,14 +323,16 @@ define(['app/module'], function (module) {
 
             scope.applyPickerDates = function () {
               var foundChange = false;
-              if (assignIfDifferent(
-                mlUtil.moment(scope.pickerDateStart),
+              var dStart = mlUtil.moment(scope.pickerDateStart);
+              var dEnd = mlUtil.moment(scope.pickerDateEnd).add('d', 1);
+              if (dStart.isValid() && assignIfDifferent(
+                dStart,
                 scope.constraints.dateStart
               )) {
                 foundChange = true;
               }
-              if (assignIfDifferent(
-                mlUtil.moment(scope.pickerDateEnd).add('d', 1),
+              if (dEnd.isValid() && assignIfDifferent(
+                dEnd,
                 scope.constraints.dateEnd
               )) {
                 foundChange = true;
@@ -405,6 +405,10 @@ define(['app/module'], function (module) {
                   scope.dateEndPlaceholder = mlUtil.moment(
                     dateToPickerEnd(newData[newData.length - 1].x)
                   ).format('MM/DD/YYYY');
+                } 
+                else {
+                  scope.dateStartPlaceholder = null;
+                  scope.dateEndPlaceholder = null;
                 }
 
                 var pickerStart = scope.constraints.dateStart.value ?

--- a/browser/src/app/styles/directives/_ss-facet-date-range.scss
+++ b/browser/src/app/styles/directives/_ss-facet-date-range.scss
@@ -29,3 +29,27 @@
     width: 33%;
   }
 }
+
+.input-daterange {
+
+  .dropdown-menu {
+    table {
+       outline:none !important;
+    }
+
+    .btn { border:0px; }
+    .btn:active, .btn:focus { outline:none !important; box-shadow:none; }
+    .btn.active { box-shadow:none; background-color:#ffdb99; border-color:#ffb733; }
+    .btn.active:hover { background-color:darken(#ffdb99,10%); border-color:darken(#ffb733,10%); }
+    .btn.active .text-info { color:#333; }    
+
+    button.btn-info, 
+    button.btn-danger,
+    button.btn-success {
+      border:1px solid #ccc;
+      font-size: 10px;
+      color:#333;
+      background-color: white;
+    }
+  }
+}


### PR DESCRIPTION
browser: Date picker color scheme and typography, Close button label, Date fields clear if result list is empty

Partial fix for: Date field behavior "Type to enter date manually" - need to figure out why when applyPickerDates() fires from manual typing, why scope.pickerDateStart or scope.pickerEndStart end up set as Date objects.  Typing "1" returns a Date obj - Mon Jan 01 2001 00:00:00 GMT-0800 (PST).  

Since this is a valid date, I cannot use Moment's date validation to check to see if what was typed is valid.   So if we figure out how to keep the input from being cast as a Date object, the commit below should work for manually typed date ranges.