### PR TITLE
Combined payload

### DIFF
--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
@@ -308,16 +308,18 @@ public class MarkLogicQnAService extends MarkLogicBaseService implements
 
 	@Override
 	public ObjectNode rawSearch(ClientRole role, ObjectNode structuredQuery,
-			long start, ArrayNode qtext, boolean includeDateFacet) {
+			long start, boolean includeDateFacet) {
 		ObjectNode docNode = mapper.createObjectNode();
 		ObjectNode searchNode = docNode.putObject("search");
 		if (structuredQuery != null) {
-			searchNode.setAll(structuredQuery);
+			if (structuredQuery.get("search") != null) {
+				searchNode.setAll((ObjectNode) structuredQuery.get("search"));
+			}
 		}
-		if (qtext != null) {
-			ArrayNode qtextNode = searchNode.putArray("qtext");
-			qtextNode.addAll(qtext);
-		}
+//		if (qtext != null) {
+//			ArrayNode qtextNode = searchNode.putArray("qtext");
+//			qtextNode.addAll(qtext);
+//		}
 		String period = "";
 		if (includeDateFacet) {
 			ObjectNode options = searchNode.putObject("options");
@@ -430,7 +432,7 @@ public class MarkLogicQnAService extends MarkLogicBaseService implements
 	// TODO date facet is default ON now. open issue is to control state from
 	// browser.
 	public ObjectNode rawSearch(ClientRole role, ObjectNode query, long start) {
-		return rawSearch(role, query, start, null, false);
+		return rawSearch(role, query, start, false);
 	}
 
 	@Override

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/exception/SamplestackSearchException.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/exception/SamplestackSearchException.java
@@ -11,5 +11,9 @@ public class SamplestackSearchException extends SamplestackException {
 	public SamplestackSearchException(Exception ex) {
 		super(ex);
 	}
+	
+	public SamplestackSearchException(String message) {
+		super(message);
+	}
 
 }

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/service/QnAService.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/service/QnAService.java
@@ -47,19 +47,17 @@ public interface QnAService {
 	 * 
 	 * @param role
 	 *            ClientRole on whose behalf to execute the search.
-	 * @param structuredQuery
-	 *            A JSON structured query payload, as a JSONNode.
+	 * @param combinedQuery
+	 *            A JSON combined query payload, as a JSONNode.
 	 * @param start
 	 *            Index of the first result in the result set.
-	 * @param qtext 
-     *            0 or more Qtext to be anded with structured Query.
 	 * @param includeDates
 	 *            Include facet for date values
 	 * @return A QuestionResults object containing results/snippets for the
 	 *         search.
 	 */
-	public ObjectNode rawSearch(ClientRole role, ObjectNode structuredQuery,
-			long start, ArrayNode qtext, boolean includeDates);
+	public ObjectNode rawSearch(ClientRole role, ObjectNode combinedQuery,
+			long start, boolean includeDates);
 	
 	/**
 	 * Send a [JSON] raw structured query to the server, using the options

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
@@ -74,10 +74,10 @@ public class QnADocumentController {
 		if (q == null) {
 			q = "sort:active";
 		}
-		ObjectNode structuredQuery = mapper.createObjectNode();
-		ObjectNode qtext = structuredQuery.putObject("query");
+		ObjectNode combinedQuery = mapper.createObjectNode();
+		ObjectNode qtext = combinedQuery.putObject("search");
 		qtext.put("qtext",q);
-		return qnaService.rawSearch(ClientRole.securityContextRole(), structuredQuery, start, null, true);
+		return qnaService.rawSearch(ClientRole.securityContextRole(), combinedQuery, start, true);
 	}
 
 	/**
@@ -264,37 +264,37 @@ public class QnADocumentController {
 	
 	/**
 	 * Exposes an endpoint for searching QnADocuments.
-	 * @param structuredQuery A JSON structured query.
+	 * @param combinedQuery A JSON combined query.
 	 * @param start The index of the first result to return.
 	 * @return A Search Results JSON response.
 	 */
 	@RequestMapping(value = "v1/search", method = RequestMethod.POST)
 	public @ResponseBody
-	JsonNode search(@RequestBody ObjectNode structuredQuery,
+	JsonNode search(@RequestBody ObjectNode combinedQuery,
 			@RequestParam(defaultValue = "1", required = false) long start) {
 
-		ArrayNode qtext = mapper.createArrayNode();
-		JsonNode postedStartNode = structuredQuery.get("start");
+		ObjectNode combinedQueryObject = (ObjectNode) combinedQuery.get("search");
+		JsonNode postedStartNode = combinedQueryObject.get("start");
 		if (postedStartNode != null) {
 			start = postedStartNode.asLong();
-			structuredQuery.remove("start");
+			combinedQueryObject.remove("start");
 		}
-		JsonNode postedQtextNode = structuredQuery.get("qtext");
-		if (postedQtextNode != null) {
-			if (postedQtextNode.isTextual()) {
-				qtext.add(postedQtextNode);  // just one qtext
-			} else if (postedQtextNode.isArray()) {
-				qtext.addAll((ArrayNode) postedQtextNode);
-			}
-			structuredQuery.remove("qtext");
-		}
-		JsonNode postedTimeZone = structuredQuery.get("timezone");
+//		JsonNode postedQtextNode = combinedQuery.get("qtext");
+//		if (postedQtextNode != null) {
+//			if (postedQtextNode.isTextual()) {
+//				qtext.add(postedQtextNode);  // just one qtext
+//			} else if (postedQtextNode.isArray()) {
+//				qtext.addAll((ArrayNode) postedQtextNode);
+//			}
+//			combinedQuery.remove("qtext");
+//		}
+		JsonNode postedTimeZone = combinedQueryObject.get("timezone");
 		if (postedTimeZone != null) {
 			// TODO work with time zone.
-			structuredQuery.remove("timezone");
+			combinedQueryObject.remove("timezone");
 		}
 		// TODO review for presence/absense of date facet as performance question.
-		return qnaService.rawSearch(ClientRole.securityContextRole(), structuredQuery, start, qtext, true);
+		return qnaService.rawSearch(ClientRole.securityContextRole(), combinedQuery, start, true);
 	}
 
 }

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
@@ -38,6 +38,7 @@ import com.marklogic.samplestack.domain.Contributor;
 import com.marklogic.samplestack.domain.InitialQuestion;
 import com.marklogic.samplestack.domain.QnADocument;
 import com.marklogic.samplestack.exception.SampleStackDataIntegrityException;
+import com.marklogic.samplestack.exception.SamplestackSearchException;
 import com.marklogic.samplestack.security.ClientRole;
 import com.marklogic.samplestack.service.ContributorService;
 import com.marklogic.samplestack.service.QnAService;
@@ -274,20 +275,14 @@ public class QnADocumentController {
 			@RequestParam(defaultValue = "1", required = false) long start) {
 
 		ObjectNode combinedQueryObject = (ObjectNode) combinedQuery.get("search");
+		if (combinedQueryObject == null) {
+			throw new SamplestackSearchException("A Samplestack search must have payload with root key \"search\"");
+		}
 		JsonNode postedStartNode = combinedQueryObject.get("start");
 		if (postedStartNode != null) {
 			start = postedStartNode.asLong();
 			combinedQueryObject.remove("start");
 		}
-//		JsonNode postedQtextNode = combinedQuery.get("qtext");
-//		if (postedQtextNode != null) {
-//			if (postedQtextNode.isTextual()) {
-//				qtext.add(postedQtextNode);  // just one qtext
-//			} else if (postedQtextNode.isArray()) {
-//				qtext.addAll((ArrayNode) postedQtextNode);
-//			}
-//			combinedQuery.remove("qtext");
-//		}
 		JsonNode postedTimeZone = combinedQueryObject.get("timezone");
 		if (postedTimeZone != null) {
 			// TODO work with time zone.

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/integration/service/QnAServiceIT.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/integration/service/QnAServiceIT.java
@@ -77,11 +77,11 @@ public class QnAServiceIT extends MarkLogicIntegrationIT {
 
 	@After
 	public void cleanupEachTest() throws JsonParseException, JsonMappingException, IOException {
-		ObjectNode structuredQuery = mapper.readValue(new ClassPathResource("queries/clean-range.json").getInputStream(), ObjectNode.class);
-		ObjectNode rangeQueryNode = (ObjectNode) structuredQuery.get("query").get("range-query");
+		ObjectNode combinedQuery = mapper.readValue(new ClassPathResource("queries/clean-range.json").getInputStream(), ObjectNode.class);
+		ObjectNode rangeQueryNode = (ObjectNode) combinedQuery.get("search").get("query").get("range-query");
 		rangeQueryNode.put("value", ISO8601Formatter.format(deleteSince));
 
-		ObjectNode joesQuestions = qnaService.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, structuredQuery, 1);
+		ObjectNode joesQuestions = qnaService.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, combinedQuery, 1);
 		List<String> toDelete = joesQuestions.findValuesAsText("id");
 		for (String d : toDelete) {
 			logger.debug("Cleaning up from qnatests " + d);
@@ -393,7 +393,7 @@ public class QnAServiceIT extends MarkLogicIntegrationIT {
 		
 		ObjectNode structuredQuery = getTestJson("queries/blank.json");
 		// test view-all
-		ObjectNode jsonResults = service.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, structuredQuery, 1, null, true);
+		ObjectNode jsonResults = service.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, structuredQuery, 1, true);
 		logger.info(mapper.writeValueAsString(jsonResults));
 		assertTrue("Blank query got back results", jsonResults.get("results")
 				.size() > 0);

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/integration/web/QnADocumentControllerIT.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/integration/web/QnADocumentControllerIT.java
@@ -62,11 +62,11 @@ public class QnADocumentControllerIT extends QnADocumentControllerTestImpl {
 
 	@After
 	public void cleanupEachTest() throws JsonParseException, JsonMappingException, IOException {
-		ObjectNode structuredQuery = mapper.readValue(new ClassPathResource("queries/clean-range.json").getInputStream(), ObjectNode.class);
-		ObjectNode rangeQueryNode = (ObjectNode) structuredQuery.get("query").get("range-query");
+		ObjectNode combinedQuery = mapper.readValue(new ClassPathResource("queries/clean-range.json").getInputStream(), ObjectNode.class);
+		ObjectNode rangeQueryNode = (ObjectNode) combinedQuery.get("search").get("query").get("range-query");
 		rangeQueryNode.put("value", ISO8601Formatter.format(deleteSince));
 
-		ObjectNode joesQuestions = qnaService.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, structuredQuery, 1);
+		ObjectNode joesQuestions = qnaService.rawSearch(ClientRole.SAMPLESTACK_CONTRIBUTOR, combinedQuery, 1);
 		List<String> toDelete = joesQuestions.findValuesAsText("id");
 		for (String d : toDelete) {
 			logger.debug("Cleaning up from qnatests " + d);

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/mock/MockQnAService.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/mock/MockQnAService.java
@@ -91,9 +91,9 @@ public class MockQnAService  extends MockServiceBase implements QnAService {
 	}
 
 	@Override
-	public ObjectNode rawSearch(ClientRole role, ObjectNode structuredQuery,
-			long start, ArrayNode qtxt, boolean includeDates) {
-		return rawSearch(role, structuredQuery, start);
+	public ObjectNode rawSearch(ClientRole role, ObjectNode combinedQuery,
+			long start, boolean includeDates) {
+		return rawSearch(role, combinedQuery, start);
 	}
 
 

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/unit/domain/DateFacetBuilderTest.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/unit/domain/DateFacetBuilderTest.java
@@ -21,6 +21,11 @@ public class DateFacetBuilderTest {
 	
 	@Test
 	@Ignore
+	/**
+	 * Not in use for Samplestack 1.0.0
+	 * @throws JsonProcessingException
+	 * @throws JSONException
+	 */
 	public void testDayBuilder() throws JsonProcessingException, JSONException {
 		ObjectMapper mapper = new CustomObjectMapper();
 		DateTime minDate = new DateTime(2013, 1, 31, 0, 0);
@@ -36,6 +41,11 @@ public class DateFacetBuilderTest {
 
 	@Test
 	@Ignore
+	/**
+	 * Not in use for Samplestack 1.0.0
+	 * @throws JsonProcessingException
+	 * @throws JSONException
+	 */
 	public void testWeekBuilder() throws JsonProcessingException, JSONException {
 		ObjectMapper mapper = new CustomObjectMapper();
 		DateTime minDate = new DateTime(2013, 1, 31, 0, 0);
@@ -50,6 +60,8 @@ public class DateFacetBuilderTest {
 
 	@Test
 	@Ignore
+	// TODO reactivate this test, and check on mac, when samplestack
+	// supports timezones appropriately.
 	public void testMonthBuilder() throws JsonProcessingException,
 			JSONException {
 		ObjectMapper mapper = new CustomObjectMapper();

--- a/appserver/java-spring/src/test/resources/queries/blank.json
+++ b/appserver/java-spring/src/test/resources/queries/blank.json
@@ -1,5 +1,3 @@
-{"query":
-  {
-  "qtext":""
-  }
+{"search":
+  {"qtext":""}
 }

--- a/appserver/java-spring/src/test/resources/queries/clean-range.json
+++ b/appserver/java-spring/src/test/resources/queries/clean-range.json
@@ -1,4 +1,5 @@
-{"query":
+{"search": {
+  "query":
     {"range-query":
         {
             "type":"xs:dateTime",
@@ -7,4 +8,5 @@
         	"range-operator":"GE"
     	}
 	}
+  }
 }

--- a/appserver/java-spring/src/test/resources/queries/test-tag-data-query.json
+++ b/appserver/java-spring/src/test/resources/queries/test-tag-data-query.json
@@ -1,5 +1,3 @@
-{"query":
-  {
-  "qtext":"tag:test-data-tag"
-  }
+{"search":
+  {"qtext":"tag:test-data-tag"}
 }

--- a/appserver/java-spring/src/test/resources/queries/test-timezone-query.json
+++ b/appserver/java-spring/src/test/resources/queries/test-timezone-query.json
@@ -1,5 +1,9 @@
-{
-    "query": {
+{"search":{
+   "qtext": [
+            "",
+            "sort:active"
+        ],
+   "query": {
         "and-query": {
             "queries": [
                 {
@@ -9,12 +13,9 @@
                     }
                 }
             ]
-        },
-        "qtext": [
-            "",
-            "sort:active"
-        ]
+        }
     },
     "start": 1,
     "timezone": "America/Los_Angeles"
+  }
 }

--- a/database/options/questions.json
+++ b/database/options/questions.json
@@ -1,6 +1,5 @@
 {
     "options": {
-        "additional-query": "<directory-query xmlns='http://marklogic.com/cts'><uri>/questions/</uri></directory-query>",
         "constraint": [
             {
                 "name": "askedBy",


### PR DESCRIPTION
This PR is one that contains a breaking change for /v1/search.

It is the change we discussed, whereby the search payload now looks a little more like the marklogic structured query JSON.  Where previously, a search has root "query" and customized keys inside it, now "query" contains a valid structured query, and is a child of "search" alongside customized keys.   

There are some test queries at the bottom which indicate the change -- @laurelnaiad if you see anything surprising let me know, but this PR I think is good to go in independently of the seed data changes that are coming next, and it will help me verify some of the data to have the browser working with this change.