### PR TITLE
Csrf

### DIFF
--- a/appserver/java-spring/build.gradle
+++ b/appserver/java-spring/build.gradle
@@ -34,16 +34,6 @@ version = samplestackVersion
 sourceCompatibility = samplestackSourceCompatibility
 
 /*
- * appserver
- * assembles the project, loads sample data and starts the appserver on port 8090
- */
-task appserver <<
-{
-   println "Bootstrapping, seeding and starting Samplestack appserver"
-}
-
-
-/*
  * INIT
  * Run this task to initialize a fresh MarkLogic server
  * and install security objects.
@@ -91,7 +81,7 @@ assemble.dependsOn(dbInit, dbConfigure, test)
  * FETCH SEED DATA
  */
 task seedDataFetch(type: MarkLogicFetchTask) {
-    url = "http://developer.marklogic.com/media/gh/seed-data1.7.tgz"
+    url = "http://developer.marklogic.com/media/gh/seed-data1.8.1.tgz"
     destFile = file("${buildDir}/seed.tgz")
     outputs.file destFile
 }
@@ -130,7 +120,7 @@ dbLoad.outputs.upToDateWhen { false }
 task dbClear(type: MarkLogicClearTask)
 
 
-/* use same properties for gradle and runtime */
+/* use same properties for gradle and Java runtime */
 task props(type: Copy) {
     from('.') {
         include 'gradle.properties'
@@ -138,9 +128,14 @@ task props(type: Copy) {
     into 'src/main/resources'
 }
 
-/**
- * appserver dependency
+/*
+ * appserver
+ * assembles the project, loads sample data and starts the appserver on port 8090
  */
+task appserver <<
+{
+   println "Bootstrapping, seeding and starting Samplestack appserver"
+}
 appserver.dependsOn(clean, assemble, dbLoad, bootRun)
 bootRun.shouldRunAfter(dbLoad)
 

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/SamplestackConstants.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/SamplestackConstants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2015 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.marklogic.samplestack;
 
 import java.text.SimpleDateFormat;

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
@@ -414,11 +414,6 @@ public class MarkLogicQnAService extends MarkLogicBaseService implements
 			// do nothing with facets if we couldn't add the period.
 			logger.debug("Unable to decorate facet payload with Period " + period);
 		}
-		try {
-			logger.debug(mapper.writeValueAsString(responseNode.get("facets")));
-		} catch (JsonProcessingException e) {
-			logger.debug("JSONERROR");
-		}
 		responseNode.set("facets", facetsNode);
 		return (ObjectNode) responseNode;
 	}

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/security/ApplicationSecurity.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/security/ApplicationSecurity.java
@@ -49,7 +49,6 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter {
 	 */
 	protected void configure(HttpSecurity http) throws Exception {
 		configurer.configure(http);
-		
 	}
 
 	@Override

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
@@ -39,6 +39,7 @@ import com.marklogic.samplestack.domain.InitialQuestion;
 import com.marklogic.samplestack.domain.QnADocument;
 import com.marklogic.samplestack.exception.SampleStackDataIntegrityException;
 import com.marklogic.samplestack.exception.SamplestackInvalidParameterException;
+import com.marklogic.samplestack.exception.SamplestackNotFoundException;
 import com.marklogic.samplestack.exception.SamplestackSearchException;
 import com.marklogic.samplestack.security.ClientRole;
 import com.marklogic.samplestack.service.ContributorService;
@@ -107,7 +108,12 @@ public class QnADocumentController {
 	JsonNode get(@PathVariable(value = "id") String id) {
 		Contributor contributor = contributorService.getByUserName(ClientRole.securityContextUserName());
 		QnADocument qnaDoc = qnaService.get(ClientRole.securityContextRole(), contributor, id);
-		return qnaDoc.getJson();
+		// if URL was accessed with under-privileged role, qnaDoc will be null.
+		if (qnaDoc == null) {
+			throw new SamplestackNotFoundException();
+		} else {
+			return qnaDoc.getJson();
+		}
 	}
 
 	/**

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/SessionController.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/SessionController.java
@@ -17,10 +17,8 @@ package com.marklogic.samplestack.web;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -62,20 +60,7 @@ public class SessionController {
 
 		// not logged in
 		if (ClientRole.securityContextRole() == ClientRole.SAMPLESTACK_GUEST)  {
-			CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
-
-			if (csrfToken == null) {
-				return errors.makeJsonResponse(400, "Getting unauthenticated session requires _csrf attribute");
-			}
-			else {
-				String headerName = csrfToken.getHeaderName();
-				String token = csrfToken.getToken();
-				HttpServletResponseWrapper responseWrapper = new HttpServletResponseWrapper(
-						response);
-
-				responseWrapper.addHeader(headerName, token);
-				return errors.makeJsonResponse(200, "New Session");
-			}
+			return errors.makeJsonResponse(200, "New Session");
 		}
 		else {
 			ObjectNode userNode;

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/CsrfRequestMatcher.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/CsrfRequestMatcher.java
@@ -1,0 +1,31 @@
+package com.marklogic.samplestack.web.security;
+
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+// here's how you have to hack in crsf protection for just some urls
+// https://github.com/spring-projects/spring-boot/issues/179
+public class CsrfRequestMatcher implements RequestMatcher {
+	private Pattern allowedMethods = Pattern
+			.compile("^(GET|HEAD|TRACE|OPTIONS)$");
+	private RegexRequestMatcher apiMatcher = new RegexRequestMatcher(
+			"/v1/(search|tags).*", null);
+
+	@Override
+	public boolean matches(HttpServletRequest request) {
+		// No CSRF due to allowedMethod
+		if (allowedMethods.matcher(request.getMethod()).matches())
+			return false;
+
+		// No CSRF due to api call
+		if (apiMatcher.matches(request))
+			return false;
+
+		// CSRF for everything else that is not an API call or an allowedMethod
+		return true;
+	}
+}

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/SamplestackAuthenticationEntryPoint.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/SamplestackAuthenticationEntryPoint.java
@@ -50,12 +50,19 @@ public class SamplestackAuthenticationEntryPoint implements
 	public void commence(HttpServletRequest request,
 			HttpServletResponse response, AuthenticationException authException)
 			throws IOException {
+
 		HttpServletResponseWrapper responseWrapper = new HttpServletResponseWrapper(
 				response);
-		responseWrapper.setStatus(HttpStatus.SC_UNAUTHORIZED);
-		
 		Writer out = responseWrapper.getWriter();
-		errors.writeJsonResponse(out, HttpStatus.SC_UNAUTHORIZED, "Unauthorized");
+		
+		if (request.getMethod().equals("OPTIONS")) {
+			responseWrapper.setStatus(HttpStatus.SC_OK);
+			errors.writeJsonResponse(out, HttpStatus.SC_OK, "OK");
+		}
+		else {
+			responseWrapper.setStatus(HttpStatus.SC_UNAUTHORIZED);
+			errors.writeJsonResponse(out, HttpStatus.SC_UNAUTHORIZED, "Unauthorized");
+		}
 		out.close();
 	}
 }

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/SamplestackSecurityFilters.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/security/SamplestackSecurityFilters.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2012-2015 MarkLogic Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.marklogic.samplestack.web.security;
 
 import java.io.IOException;
@@ -28,10 +13,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  *  Customization to Spring Security. 
- *  Adds CSRF token as header if it exists, and also CORS headers.
+ *  Adds CSRF token as header if it exists in the current
+ *  request, and also includes CORS headers.
  */
-@Component
-public final class SamplestackSecurityFilters extends OncePerRequestFilter {
+class SamplestackSecurityFilters extends OncePerRequestFilter {
 	@Override
 	/**
 	 * Hooks into Spring Security filter mechanism to manipulate

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/ContributorControllerTestImpl.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/ContributorControllerTestImpl.java
@@ -52,6 +52,7 @@ public class ContributorControllerTestImpl extends ControllerTests {
 
 		this.mockMvc.perform(
 				delete("/v1/contributors/" + basicUser.getId())
+				.with(csrf().asHeader())
 				.session((MockHttpSession) session)
 				.locale(Locale.ENGLISH))
 				.andExpect(status().isOk()).andReturn().getResponse();
@@ -60,7 +61,7 @@ public class ContributorControllerTestImpl extends ControllerTests {
 		login("testC1@example.com", "c1");
 		this.mockMvc.perform(
 				post("/v1/contributors")
-				.with(csrf())
+				.with(csrf().asHeader())
 				.session((MockHttpSession) session)
 						.locale(Locale.ENGLISH)
 						.contentType(MediaType.APPLICATION_JSON)
@@ -69,7 +70,7 @@ public class ContributorControllerTestImpl extends ControllerTests {
 
 		logger.debug("Basic User:" + mapper.writeValueAsString(basicUser));
 		login("testA1@example.com", "a1");
-		
+
 		MockHttpServletResponse response = this.mockMvc
 				.perform(
 						post("/v1/contributors")
@@ -107,7 +108,7 @@ public class ContributorControllerTestImpl extends ControllerTests {
 
 		assertEquals("Id name matches when get By ID", getById.getId(),
 				returnedUser.getId());
-		
+
 		logout();
 		getById = mapper.readValue(
 				this.mockMvc
@@ -120,11 +121,12 @@ public class ContributorControllerTestImpl extends ControllerTests {
 
 		assertEquals("Id name matches when get By ID", getById.getId(),
 				returnedUser.getId());
-		
+
 		login("testA1@example.com", "a1");
-		
+
 		this.mockMvc.perform(
 				delete("/v1/contributors/" + returnedUser.getId())
+				.with(csrf().asHeader())
 				.session((MockHttpSession) session)
 				.locale(Locale.ENGLISH))
 				.andExpect(status().isOk()).andReturn().getResponse();

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/ControllerTests.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/ControllerTests.java
@@ -97,7 +97,7 @@ public class ControllerTests {
 		MvcResult result = mockMvc
 				.perform(
 						post("/v1/session")
-						//.with(csrf().asHeader())
+						.with(csrf().asHeader())
 						.param("username", username)
 						.param("password", password))
 				// TODO 'restful' login content(loginBody(username, password)))
@@ -109,7 +109,8 @@ public class ControllerTests {
 	}
 
 	protected void logout() throws Exception {
-		this.session = this.mockMvc.perform(delete("/v1/session"))
+		this.session = this.mockMvc.perform(delete("/v1/session")
+				.with(csrf().asHeader()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getRequest().getSession();

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/LoginTestsImpl.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/LoginTestsImpl.java
@@ -111,7 +111,7 @@ public class LoginTestsImpl extends ControllerTests {
 		
 		logout();
 		mockMvc.perform(
-				post("/v1/contributors").session((MockHttpSession) session).locale(
+				post("/v1/contributors").with(csrf().asHeader()).session((MockHttpSession) session).locale(
 						Locale.ENGLISH)).andDo(print())
 				.andExpect(status().isUnauthorized());
 		

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/TagControllerTestImpl.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/testing/TagControllerTestImpl.java
@@ -16,6 +16,7 @@
 package com.marklogic.samplestack.testing;
 
 import static org.junit.Assert.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,7 +36,8 @@ public class TagControllerTestImpl extends ControllerTests {
 	
 	public void testTagsAnonymousOK() throws Exception {
 		this.mockMvc.perform(
-				post("/v1/tags").contentType(MediaType.APPLICATION_JSON)
+				post("/v1/tags").with(csrf().asHeader())
+				        .contentType(MediaType.APPLICATION_JSON)
 						.content("{\"search\":{\"qtext\":\"true\"}}")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk());
@@ -45,7 +47,8 @@ public class TagControllerTestImpl extends ControllerTests {
 		login("testC1@example.com", "c1");
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags").session((MockHttpSession) session)
+						post("/v1/tags").with(csrf().asHeader())
+						        .session((MockHttpSession) session)
 								.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andReturn();
 		JSONAssert.assertEquals("{values-response:{name:\"tags\"}}", result
@@ -60,7 +63,8 @@ public class TagControllerTestImpl extends ControllerTests {
 		login("testC1@example.com", "c1");
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags").session((MockHttpSession) session)
+						post("/v1/tags").with(csrf().asHeader())
+						        .session((MockHttpSession) session)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content("{\"search\":{\"forTag\":\"ada\",\"qtext\":[\"tag:test-data-tag\"]}}")
 								.accept(MediaType.APPLICATION_JSON))
@@ -77,7 +81,7 @@ public class TagControllerTestImpl extends ControllerTests {
 	public void testTagsWithPageLength() throws Exception {
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags")
+						post("/v1/tags").with(csrf().asHeader())
 								.contentType(MediaType.APPLICATION_JSON)
 								.content("{\"search\":{\"pageLength\":1}}")
 								.accept(MediaType.APPLICATION_JSON))
@@ -95,7 +99,7 @@ public class TagControllerTestImpl extends ControllerTests {
 	public void testStartLimitOrder() throws Exception {
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags")
+						post("/v1/tags").with(csrf().asHeader())
 								.contentType(MediaType.APPLICATION_JSON)
 								.content("{\"search\":{\"start\":3,"
 										+ "\"sort\":\"name\"}}")
@@ -112,7 +116,8 @@ public class TagControllerTestImpl extends ControllerTests {
 
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags").session((MockHttpSession) session)
+						post("/v1/tags").with(csrf().asHeader())
+						        .session((MockHttpSession) session)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content("{\"search\":{\"start\":1,"
 										+ "\"sort\":\"frequency\","
@@ -129,7 +134,7 @@ public class TagControllerTestImpl extends ControllerTests {
 		@SuppressWarnings("unused")
 		MvcResult result = this.mockMvc
 				.perform(
-						post("/v1/tags")
+						post("/v1/tags").with(csrf().asHeader())
 								.contentType(MediaType.APPLICATION_JSON)
 								.content("{\"search\":{\"sort\":\"bug\"}}")
 								.accept(MediaType.APPLICATION_JSON))

--- a/database/transforms/search-response.sjs
+++ b/database/transforms/search-response.sjs
@@ -82,12 +82,22 @@ function searchTransform(context, params, input) {
                 var sourceDoc = fn.doc(uri).next().value;
                 for (var j = 0; j < matches.length; j++) {
                     var match = matches[j];
-                    var source = "question";
+                    var source = "";
                     if (match.path.indexOf("answers") > -1) {
                         source = "answer";                
                     }
                     else if (match.path.indexOf("tags") > -1) {
                         source = "tags";
+                    }
+                    else if (match.path.indexOf('text("text")') > -1) {
+                        source = "question";
+                    }
+                    else if (match.path.indexOf('text("title")') > -1) {
+                        source = "question";
+                    }
+                    else {
+                        match = null;
+                        continue;
                     }
                     match.source = source;
                     if (source == "answer") {
@@ -106,11 +116,13 @@ function searchTransform(context, params, input) {
                         } else {
                             match.id = "error - unknown";
                         }
-                    } else {
-                        var root = sourceDoc.toObject();
-                        if (root.id !== undefined) {
-                            match.id = root.id;
+                    } else if (source == "question") {
+                        var id = sourceDoc.root.id;
+                        if (id !== undefined) {
+                            match.id = id;
                         }
+                    } else {
+                        match.id = "";
                     }
                     delete match.path;
                 }


### PR DESCRIPTION
EDIT: Just added CORS (partial?) fix for OPTIONS methods, and for a snippets adjustment to the search response.


This PR brings CSRF online as we've agreed, and has three minor issue-fixing commits.

CSRF fixed - #41 
GET /v1/session  -- a header arrives with the response X-CSRF-TOKEN
POST /v1/session -- login.  token must be present as header.  A NEW TOKEN is returned, but the session remains the same.  
subsequent requests in the session use this new token.    I've played with this significantly and it appears to work as promised.  So cross fingers on easy integration.


Other commits in this PR
copyright straggler.
seed data update that fixes #362 
page length bug in tags that fixes #476 