### PR TITLE
Use tomcat rather than jetty

### DIFF
--- a/appserver/java-spring/build.gradle
+++ b/appserver/java-spring/build.gradle
@@ -150,10 +150,7 @@ repositories {
 dependencies {
     compile "org.codehaus.groovy:groovy-all:2.3.7"
     compile("org.springframework.boot:spring-boot-starter-security:${springBootVersion}")
-    compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {
-        exclude(group: "org.springframework.boot", module: "spring-boot-starter-tomcat")
-    }
-    compile("org.springframework.boot:spring-boot-starter-jetty:${springBootVersion}")
+    compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
     compile("org.springframework.security:spring-security-ldap:4.0.0.RC1")
     compile("org.springframework.security:spring-security-web:4.0.0.RC1")
     compile("org.springframework.security:spring-security-test:4.0.0.RC1")


### PR DESCRIPTION
This change to build.gradle swaps out the web server in use for the middle tier.  It seems that the delay in issue #395 happens within Jetty code, and by using the alternative web server the startup is avoided.  This should not change anything else about the middle tier or the application.  But if it helps, it should be a relief for us all.