### PR TITLE
set timeout explicitly in node proxy for rest server

### DIFF
--- a/browser/dev-tasks/context.js
+++ b/browser/dev-tasks/context.js
@@ -255,15 +255,19 @@ self = module.exports = {
       });
 
       var server = connect()
-        .use('/v1/', function (req, res) {
-          req.pipe(
-            request(options.addresses.appServer.href + 'v1' + req.url)
-          )
-          .on('error', function (err) {
-            console.log(err);
+      .use('/v1/', function (req, res) {
+        req.pipe(
+          request({
+            url: options.addresses.appServer.href + 'v1' + req.url,
+            // 31 seconds, one more than the browser will wait
+            timeout: 31 * 1000
           })
-          .pipe(res);
-        });
+        )
+        .on('error', function (err) {
+          console.log(err);
+        })
+        .pipe(res);
+      });
 
       if (options.html5Mode) {
         server.use(
@@ -275,8 +279,8 @@ self = module.exports = {
       }
 
       var listener = server
-        .use(serveStatic(path.normalize(filePath), {redirect: false}))
-        .listen(port, '0.0.0.0');
+      .use(serveStatic(path.normalize(filePath), {redirect: false}))
+      .listen(port, '0.0.0.0');
 
       listener.on('error', function (err) {
         console.log(err);
@@ -305,83 +309,83 @@ self = module.exports = {
       app.use('/coverage', im.createHandler());
       app.use(im.createClientHandler(
         path.resolve(testerPath),
-        {
-          matcher: function (req) {
-            // cover js files that aren't .unit.js and are not ext dependencies
-            var parsed = url.parse(req.url).pathname;
-            if (!/\.js$/.test(parsed)) {
-              return false;
-            }
-            if (parsed.match(/index\.js/)) {
-              // its a modules index file
-              return false;
-            }
-            if (!(parsed.match(/^\/.+\/.+\//))) {
-              // it's not deep enough to be the code we really want to test
-              return false;
-            }
-            if (parsed.match(/^\/mocks\//)) {
-              // it's part of the mocks modules
-              return false;
-            }
-            var isBrowserify = /\.browserify\.js$/.test(parsed);
-            var isTestCode = /\.unit\.js$/.test(parsed);
-            // console.log(parsed + ' is test code: ' + isTestCode);
-            var isDependency = /^\/deps\//.test(parsed);
-            // console.log(parsed + ' is dep. code: ' + isDependency);
-            return !(isTestCode || isBrowserify || isDependency);
+      {
+        matcher: function (req) {
+          // cover js files that aren't .unit.js and are not ext dependencies
+          var parsed = url.parse(req.url).pathname;
+          if (!/\.js$/.test(parsed)) {
+            return false;
           }
-          // pathTransformer: function (req) {
-          // }
+          if (parsed.match(/index\.js/)) {
+            // its a modules index file
+            return false;
+          }
+          if (!(parsed.match(/^\/.+\/.+\//))) {
+            // it's not deep enough to be the code we really want to test
+            return false;
+          }
+          if (parsed.match(/^\/mocks\//)) {
+            // it's part of the mocks modules
+            return false;
+          }
+          var isBrowserify = /\.browserify\.js$/.test(parsed);
+          var isTestCode = /\.unit\.js$/.test(parsed);
+          // console.log(parsed + ' is test code: ' + isTestCode);
+          var isDependency = /^\/deps\//.test(parsed);
+          // console.log(parsed + ' is dep. code: ' + isDependency);
+          return !(isTestCode || isBrowserify || isDependency);
         }
-      ));
-      app.use(bodyParser.urlencoded({ extended: true }));
-      app.use(bodyParser.json());
-
-      app.use(express['static'](path.resolve(testerPath)));
-      var httpServer = require('http').createServer(app);
-      httpServer.listen(port,'0.0.0.0');
-
-      self.setActiveServer(port, httpServer);
-    }
-  },
-
-  currentTask: argv._[0] || 'default',
-
-  parentPid: function () {
-    return argv.parentPid;
-  },
-
-
-  restartChild: function () {
-    var start = function () {
-      var argsArray = process.argv.slice(2);
-      gulpChild = childProcess.fork(
-        path.resolve(
-          __dirname, '../node_modules/gulp/bin/gulp.js'
-        ),
-        argsArray.concat('--parent-pid=' + process.pid),
-        { cwd: process.cwd() }
-      );
-
-      gulpChild.on('message', function (m) {
-        if (m.restartChild) {
-          self.restartChild();
-        }
-      });
-    };
-
-    if (self.parentPid()) {
-      process.send( {'restartChild': true });
-    }
-    else {
-      if (gulpChild) {
-        gulpChild.on('exit', start);
-        gulpChild.kill('SIGINT');
+        // pathTransformer: function (req) {
+        // }
       }
-      else {
-        start();
-      }
-    }
+    ));
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(bodyParser.json());
+
+    app.use(express['static'](path.resolve(testerPath)));
+    var httpServer = require('http').createServer(app);
+    httpServer.listen(port,'0.0.0.0');
+
+    self.setActiveServer(port, httpServer);
   }
+},
+
+currentTask: argv._[0] || 'default',
+
+parentPid: function () {
+  return argv.parentPid;
+},
+
+
+restartChild: function () {
+  var start = function () {
+    var argsArray = process.argv.slice(2);
+    gulpChild = childProcess.fork(
+      path.resolve(
+        __dirname, '../node_modules/gulp/bin/gulp.js'
+      ),
+      argsArray.concat('--parent-pid=' + process.pid),
+    { cwd: process.cwd() }
+  );
+
+  gulpChild.on('message', function (m) {
+    if (m.restartChild) {
+      self.restartChild();
+    }
+  });
+};
+
+if (self.parentPid()) {
+  process.send( {'restartChild': true });
+}
+else {
+  if (gulpChild) {
+    gulpChild.on('exit', start);
+    gulpChild.kill('SIGINT');
+  }
+  else {
+    start();
+  }
+}
+}
 };


### PR DESCRIPTION
As part of #395, "warm-up" issue...

Ensure proxy tries to stay open waiting for middle-tier requests for
31 seconds, giving it as much time as we can to respond.