### PR TITLE
browser: on ask page, do not show selected tags in tags-input list

### DIFF
--- a/appserver/java-spring/static/app/states/ask.js
+++ b/appserver/java-spring/static/app/states/ask.js
@@ -28,10 +28,24 @@ define(['app/module'], function (module) {
           .then(function (response) {
             var tagsArr = [];
             angular.forEach(response.results.items, function (value, key) {
-              tagsArr.push({'text': value.name + ' (' + value.count + ')'});
+              // do not show selected tags in list
+              if (!$scope.tagSelected(value)) {
+                tagsArr.push({'text': value.name + ' (' + value.count + ')'});
+              }
             });
             return tagsArr;
           });
+      };
+
+      // Is tag selected already?
+      $scope.tagSelected = function (tag) {
+        result = false;
+        angular.forEach($scope.tagsInput, function (value, key) {
+          if (tag.name === value.text) {
+            result = true;
+          }
+        });
+        return result;
       };
 
       // Remove trailing freq in parens

--- a/browser/src/app/states/ask.js
+++ b/browser/src/app/states/ask.js
@@ -28,10 +28,24 @@ define(['app/module'], function (module) {
           .then(function (response) {
             var tagsArr = [];
             angular.forEach(response.results.items, function (value, key) {
-              tagsArr.push({'text': value.name + ' (' + value.count + ')'});
+              // do not show selected tags in list
+              if (!$scope.tagSelected(value)) {
+                tagsArr.push({'text': value.name + ' (' + value.count + ')'});
+              }
             });
             return tagsArr;
           });
+      };
+
+      // Is tag selected already?
+      $scope.tagSelected = function (tag) {
+        result = false;
+        angular.forEach($scope.tagsInput, function (value, key) {
+          if (tag.name === value.text) {
+            result = true;
+          }
+        });
+        return result;
       };
 
       // Remove trailing freq in parens


### PR DESCRIPTION
#closes 533

To test:
1. On the Ask a Question page, type a 'jav' string in the tags-input field.
2. Select 'javascript' from the menu list. The selected tag becomes a chiclet.
3. Type 'jav' again in the tags-input, now 'javascript' will not appear in the menu list.