### PR TITLE
browser (documentation): dialogs and states (ask, qnaDoc)

### DIFF
--- a/appserver/java-spring/static/app/dialogs/contributor.js
+++ b/appserver/java-spring/static/app/dialogs/contributor.js
@@ -4,16 +4,22 @@ define(['app/module'], function (module) {
    * @ngdoc controller
    * @kind constructor
    * @name contributorDialogCtlr
+   * @description
+   * Controller for the {@link contributorDialog}. The controller
+   * is injected by the $modal service. Upon instantiation, the controller
+   * looks up the specified contributor by ID on the server. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
+   *
    * @param {angular.Scope} $scope (injected)
    * @param {ui.bootstrap.modal.$modalInstance} $modalInstance (injected)
-   * @param {object} ssContributor
-   * @param {string} contributorId
-   * @description Controller for the {@link contributorDialog}. The controller
-   * is
-   * injected by the $modal service.
+   * @param {object} ssContributor respresents a Samplestack contributor with
+   * properties for displayName, reputation, etc.
+   * @param {string} contributorId The ID of the contributor whose information
+   * is displayed
    *
-   * Upon instantiation the `contributorDialogCtlr` looks up the specified
-   * contributor by id on the server.
+   * @property {ssContributor} $scope.contributor a Samplestack contributor
+   * @property {boolean} $scope.notFound set to true if contributor not found
    */
   module.controller('contributorDialogCtlr', [
     '$scope', '$modalInstance', 'ssContributor', 'contributorId',
@@ -31,7 +37,7 @@ define(['app/module'], function (module) {
       /**
        * @ngdoc method
        * @name contributorDialogCtlr#$scope.cancel
-       * @description Dismisses the modal (without logging in).
+       * @description Dismisses the dialog
        */
       $scope.cancel = function () {
         $modalInstance.dismiss();
@@ -42,16 +48,16 @@ define(['app/module'], function (module) {
 
   /**
    * @ngdoc dialog
-   * @name contributorDialog
    * @kind function
-   * @param {string} contributorId The id of the contributor whose information
-   * should
-   * be displayed
-   * @description The
-   * contributor dialog displays information about a contributor.
+   * @name contributorDialog
+   * @description A UI Bootstrap component that provides a modal dialog for
+   * information about a Samplestack contributor. When called, this service
+   * configures the dialog and the controller {@link contributorDialogCtlr},
+   * and launches the dialog using the template. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
    *
-   * This is the service that configures the dialog and the
-   * {@link contributorDialogCtlr}, and launches the dialog.
+   * @param {string} contributorId The ID of the contributor
    */
   module.factory('contributorDialog', [
     '$modal',

--- a/appserver/java-spring/static/app/dialogs/login.js
+++ b/appserver/java-spring/static/app/dialogs/login.js
@@ -4,21 +4,23 @@ define(['app/module'], function (module) {
    * @ngdoc controller
    * @kind constructor
    * @name loginDialogCtlr
+   * @description
+   * Controller for {@link loginDialog}. The controller is injected by the
+   * $modal service. Provides a user interface for authenticating a user.
+   * Upon instantiation the `loginDialogCtlr` creates an empty instance of
+   * {@link ssSession} for handling authentication. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
+   *
    * @param {angular.Scope} $scope (injected)
    * @param {ui.bootstrap.modal.$modalInstance} $modalInstance (injected)
    * @param {object} ssSession Session object
    * @param {object} mlAuth Authentication object
-   * @description
-   * Controller for {@link loginDialog}. The controller is injected by the
-   * $modal service.
    *
-   * Used to provide a user interface through which to autenticate a user.
-   *
-   * Upon instantiation the `loginDialogCtlr` creates an empty instance of
-   * {@link ssSession} for handling authentication.
-   *
-   * @property {string} $scope.error If present, indicates textually what
-   * error occured while attempting to authenticate a user.
+   * @property {string} $scope.error If present, indicates what error
+   * occurred while attempting to authenticate a user.
+   * @property {string} $scope.session.username The username input.
+   * @property {string} $scope.session.password The password input.
    */
   module.controller('loginDialogCtlr', [
 
@@ -67,10 +69,23 @@ define(['app/module'], function (module) {
         );
       };
 
+      /**
+       * @ngdoc method
+       * @name loginDialogCtlr#$scope.onAuthSuccess
+       * @description Called upon successful authentication and closes the
+       * dialog.
+       */
       var onAuthSuccess = function (user) {
         $modalInstance.close(user);
       };
 
+      /**
+       * @ngdoc method
+       * @name loginDialogCtlr#$scope.onAuthFailure
+       * @description Called upon failed authentication. Sets the error message
+       * and attaches a ssSession object with username information only to
+       * scope.
+       */
       var onAuthFailure = function (reason) {
         $scope.error = 'Login Failed: ' + reason;
         ssSession.create( { username: $scope.session.username })
@@ -80,7 +95,7 @@ define(['app/module'], function (module) {
       /**
        * @ngdoc method
        * @name loginDialogCtlr#$scope.cancel
-       * @description Dismisses the dialog.
+       * @description Dismisses the dialog (without logging in)
        */
       $scope.cancel = function () {
         $modalInstance.dismiss();
@@ -107,11 +122,12 @@ define(['app/module'], function (module) {
    * @ngdoc dialog
    * @name loginDialog
    * @kind function
-   *
-   * @description User interface for logging into the Samplestack application.
-   *
-   * This is the service that cobfigures the dialog and
-   * the {@link loginDialogCtlr}, and launches the dialog.
+   * @description A UI Bootstrap component that provides a modal dialog for
+   * logging into the Samplestack application. When called, this service
+   * configures the dialog and the controller {@link loginDialogCtlr}, and
+   * launches the dialog using the template. The size property controls the
+   * size of the dialog. See <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
    */
   module.factory('loginDialog', [
     '$modal',

--- a/appserver/java-spring/static/app/domain/ssContributor.js
+++ b/appserver/java-spring/static/app/domain/ssContributor.js
@@ -57,6 +57,7 @@ define(['app/module'], function (module) {
             id: { type: 'string', minLength: 36, maxLength: 36 },
             location: { type: [ 'string', 'null' ]},
             voteCount: { type: [ 'integer' ] }
+            // displayName???
           }
         })
       };

--- a/appserver/java-spring/static/app/states/ask.js
+++ b/appserver/java-spring/static/app/states/ask.js
@@ -1,5 +1,23 @@
 define(['app/module'], function (module) {
 
+  /**
+   * @ngdoc controller
+   * @kind constructor
+   * @name askCtlr
+   * @description
+   * Controller for the ask root.layout.ask ui-router state, which
+   * provides an interface for asking a Samplestack question. Upon
+   * instantiation of the controller, an ssQnaDoc object is created
+   * for the new question and this object is attached to the $scope
+   * as $scope.qnaDoc.
+   *
+   * @param {angular.Scope} $scope (injected)
+   * @param {object} appRouting (injected)
+   * @param {object} ssQnaDoc The question model object.
+   *
+   * @property {Array.string} $scope.tagsInput An array of selected
+   * tag names.
+   */
   module.controller('askCtlr', [
 
     '$scope', 'appRouting', 'ssQnaDoc', 'ssTagsSearch',
@@ -54,6 +72,14 @@ define(['app/module'], function (module) {
         return tag;
       };
 
+      /**
+       * @ngdoc method
+       * @name askCtlr#$scope.save
+       * @description Posts the new question to the server if the question is
+       * valid, then redirects the user to the root.layout.qnaDoc view for
+       * that new question. If the question is invalid, an error message is
+       * displayed.
+       */
       $scope.save = function () {
 
         // convert tags-input data from array of objects to array of strings

--- a/appserver/java-spring/static/app/states/qnaDoc.js
+++ b/appserver/java-spring/static/app/states/qnaDoc.js
@@ -1,5 +1,38 @@
 define(['app/module'], function (module) {
 
+  /**
+   * @ngdoc controller
+   * @kind constructor
+   * @name qnaDocCtlr
+   * @description
+   * Controller for the ask root.layout.qnaDoc ui-router state, which
+   * displays a Samplestack question and its associated answers and
+   * comments. Upon instantiation of the controller, an ssQnaDoc for
+   * the question is created based on an ID parameter. The answers and
+   * comments are represented by ssAnswer and ssComment sub-objects
+   * of ssQnaDoc. The view also displays voting history information
+   * and authenticated users can cast votes and accept answers.
+   *
+   * @param {angular.Scope} $scope (injected)
+   * @param {object} $timeout (injected)
+   * @param {object} marked For parsing and displaying markdown content.
+   * @param {object} appRouting (injected)
+   * @param {object} ssQnaDoc Question model object.
+   * @param {object} ssAnswer Answer model object.
+   * @param {object} ssComment Comment model object.
+   * @param {object} ssVote Vote model object.
+   * @param {object} ssAcceptedAnswer Accepted answer model object.
+   *
+   * @property {boolean} $scope.setLoading Flag set to true when page
+   * data is loading.
+   * @property {ssQnaDoc} $scope.doc The document object to be displayed.
+   * @property {boolean} $scope.showQuestionComment Flag set to true
+   * when question comment form should be displayed.
+   * @property {Array.<object>} $scope.showAnswerComment Array of objects,
+   * one per answer, that determine whether to display an answer comment
+   * form.
+   * @property {object} $scope.draftAnswer A draft object for new answers.
+   */
   module.controller('qnaDocCtlr', [
 
     '$scope',
@@ -30,7 +63,8 @@ define(['app/module'], function (module) {
           { id: appRouting.params.id },
           // by passing a contributorId we instigate the getting
           // and availability of voting properties on the content
-          // objects
+          // objects [TODO Is this still relevant since /hasVoted
+          // endpoint is now gone?]
           $scope.store.session ? $scope.store.session.id : null
         );
         doc.$ml.waiting.then(
@@ -73,6 +107,7 @@ define(['app/module'], function (module) {
 
       };
 
+      // Handle search queries from the search bar
       $scope.$on('setQueryText', function (evt, arg) {
         appRouting.go('root.layout.explore.results', {
           q: $scope.dasherize(arg.queryText)
@@ -81,8 +116,10 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canVoteOn
-      * @description Returns whether current user can vote on the object
+      * @name qnaDocCtlr#$scope.canVoteOn
+      * @description Returns whether current user can vote on the object.
+      * Votes can be cast on questions and answers.
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.canVoteOn = function (obj) {
@@ -97,8 +134,9 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.hasVotedUp
+      * @name qnaDocCtlr#$scope.hasVotedUp
       * @description Returns whether current user has upvoted the object
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.hasVotedUp = function (obj) {
@@ -114,8 +152,9 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.hasVotedDown
+      * @name qnaDocCtlr#$scope.hasVotedDown
       * @description Returns whether current user has downvoted the object
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.hasVotedDown = function (obj) {
@@ -159,7 +198,7 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canAcceptAnswer
+      * @name qnaDocCtlr#$scope.canAcceptAnswer
       * @description Returns whether current user can accept
       * an answer associated with the QnaDoc.
       * @param {ssAnswer} answer The ssAnswer object.
@@ -174,20 +213,35 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canAnswer
+      * @name qnaDocCtlr#$scope.canAnswer
       * @description Returns whether current user can submit
       * an answer to the QnaDoc.
+      * @param {ssAnswer} answer The ssAnswer object.
       * @returns {boolean} true or false
       */
       $scope.canAnswer = function (answer) {
         return $scope.store.session;
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.answersCountLabel
+      * @description Returns a singular or plural answers label based on
+      * the number of answers.
+      * @returns {string} A label
+      */
       $scope.answersCountLabel = function () {
         var len = $scope.doc.answers.length;
         return len + (len === 1 ? ' Answer' : ' Answers');
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.marked
+      * @description Parses markdown-formatted text.
+      * @param {string} text Text to be parsed.
+      * @returns {string} Parsed text
+      */
       $scope.marked = function (text) {
         return marked(text);
       };
@@ -196,6 +250,12 @@ define(['app/module'], function (module) {
         appRouting.go('^.explore', { q: $scope.searchbarText });
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveAnswer
+      * @description Saves an answer if valid.
+      * @param {ssAnswer} answer Answer to be saved.
+      */
       $scope.saveAnswer = function (answer) {
         if (answer.$ml.valid) {
           answer.post().$ml.waiting.then(
@@ -217,6 +277,11 @@ define(['app/module'], function (module) {
         }
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveQuestionComment
+      * @description Saves a question comment if valid.
+      */
       $scope.saveQuestionComment = function () {
         var comment = $scope.doc.comments.draft;
         if (comment.$ml.valid) {
@@ -236,6 +301,11 @@ define(['app/module'], function (module) {
         }
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveAnswerComment
+      * @description Saves an answer comment if valid.
+      */
       $scope.saveAnswerComment = function (answer) {
         var comment = answer.comments.draft;
         if (comment.$ml.valid) {

--- a/browser/src/app/dialogs/contributor.js
+++ b/browser/src/app/dialogs/contributor.js
@@ -4,16 +4,22 @@ define(['app/module'], function (module) {
    * @ngdoc controller
    * @kind constructor
    * @name contributorDialogCtlr
+   * @description
+   * Controller for the {@link contributorDialog}. The controller
+   * is injected by the $modal service. Upon instantiation, the controller
+   * looks up the specified contributor by ID on the server. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
+   *
    * @param {angular.Scope} $scope (injected)
    * @param {ui.bootstrap.modal.$modalInstance} $modalInstance (injected)
-   * @param {object} ssContributor
-   * @param {string} contributorId
-   * @description Controller for the {@link contributorDialog}. The controller
-   * is
-   * injected by the $modal service.
+   * @param {object} ssContributor respresents a Samplestack contributor with
+   * properties for displayName, reputation, etc.
+   * @param {string} contributorId The ID of the contributor whose information
+   * is displayed
    *
-   * Upon instantiation the `contributorDialogCtlr` looks up the specified
-   * contributor by id on the server.
+   * @property {ssContributor} $scope.contributor a Samplestack contributor
+   * @property {boolean} $scope.notFound set to true if contributor not found
    */
   module.controller('contributorDialogCtlr', [
     '$scope', '$modalInstance', 'ssContributor', 'contributorId',
@@ -31,7 +37,7 @@ define(['app/module'], function (module) {
       /**
        * @ngdoc method
        * @name contributorDialogCtlr#$scope.cancel
-       * @description Dismisses the modal (without logging in).
+       * @description Dismisses the dialog
        */
       $scope.cancel = function () {
         $modalInstance.dismiss();
@@ -42,16 +48,16 @@ define(['app/module'], function (module) {
 
   /**
    * @ngdoc dialog
-   * @name contributorDialog
    * @kind function
-   * @param {string} contributorId The id of the contributor whose information
-   * should
-   * be displayed
-   * @description The
-   * contributor dialog displays information about a contributor.
+   * @name contributorDialog
+   * @description A UI Bootstrap component that provides a modal dialog for
+   * information about a Samplestack contributor. When called, this service
+   * configures the dialog and the controller {@link contributorDialogCtlr},
+   * and launches the dialog using the template. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
    *
-   * This is the service that configures the dialog and the
-   * {@link contributorDialogCtlr}, and launches the dialog.
+   * @param {string} contributorId The ID of the contributor
    */
   module.factory('contributorDialog', [
     '$modal',

--- a/browser/src/app/dialogs/login.js
+++ b/browser/src/app/dialogs/login.js
@@ -4,21 +4,23 @@ define(['app/module'], function (module) {
    * @ngdoc controller
    * @kind constructor
    * @name loginDialogCtlr
+   * @description
+   * Controller for {@link loginDialog}. The controller is injected by the
+   * $modal service. Provides a user interface for authenticating a user.
+   * Upon instantiation the `loginDialogCtlr` creates an empty instance of
+   * {@link ssSession} for handling authentication. See
+   * <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
+   *
    * @param {angular.Scope} $scope (injected)
    * @param {ui.bootstrap.modal.$modalInstance} $modalInstance (injected)
    * @param {object} ssSession Session object
    * @param {object} mlAuth Authentication object
-   * @description
-   * Controller for {@link loginDialog}. The controller is injected by the
-   * $modal service.
    *
-   * Used to provide a user interface through which to autenticate a user.
-   *
-   * Upon instantiation the `loginDialogCtlr` creates an empty instance of
-   * {@link ssSession} for handling authentication.
-   *
-   * @property {string} $scope.error If present, indicates textually what
-   * error occured while attempting to authenticate a user.
+   * @property {string} $scope.error If present, indicates what error
+   * occurred while attempting to authenticate a user.
+   * @property {string} $scope.session.username The username input.
+   * @property {string} $scope.session.password The password input.
    */
   module.controller('loginDialogCtlr', [
 
@@ -67,10 +69,23 @@ define(['app/module'], function (module) {
         );
       };
 
+      /**
+       * @ngdoc method
+       * @name loginDialogCtlr#$scope.onAuthSuccess
+       * @description Called upon successful authentication and closes the
+       * dialog.
+       */
       var onAuthSuccess = function (user) {
         $modalInstance.close(user);
       };
 
+      /**
+       * @ngdoc method
+       * @name loginDialogCtlr#$scope.onAuthFailure
+       * @description Called upon failed authentication. Sets the error message
+       * and attaches a ssSession object with username information only to
+       * scope.
+       */
       var onAuthFailure = function (reason) {
         $scope.error = 'Login Failed: ' + reason;
         ssSession.create( { username: $scope.session.username })
@@ -80,7 +95,7 @@ define(['app/module'], function (module) {
       /**
        * @ngdoc method
        * @name loginDialogCtlr#$scope.cancel
-       * @description Dismisses the dialog.
+       * @description Dismisses the dialog (without logging in)
        */
       $scope.cancel = function () {
         $modalInstance.dismiss();
@@ -107,11 +122,12 @@ define(['app/module'], function (module) {
    * @ngdoc dialog
    * @name loginDialog
    * @kind function
-   *
-   * @description User interface for logging into the Samplestack application.
-   *
-   * This is the service that cobfigures the dialog and
-   * the {@link loginDialogCtlr}, and launches the dialog.
+   * @description A UI Bootstrap component that provides a modal dialog for
+   * logging into the Samplestack application. When called, this service
+   * configures the dialog and the controller {@link loginDialogCtlr}, and
+   * launches the dialog using the template. The size property controls the
+   * size of the dialog. See <a href="http://angular-ui.github.io/bootstrap/"
+   * target="_blank">ui.bootstrap.modal</a> for more information.
    */
   module.factory('loginDialog', [
     '$modal',

--- a/browser/src/app/domain/ssContributor.js
+++ b/browser/src/app/domain/ssContributor.js
@@ -57,6 +57,7 @@ define(['app/module'], function (module) {
             id: { type: 'string', minLength: 36, maxLength: 36 },
             location: { type: [ 'string', 'null' ]},
             voteCount: { type: [ 'integer' ] }
+            // displayName???
           }
         })
       };

--- a/browser/src/app/states/ask.js
+++ b/browser/src/app/states/ask.js
@@ -1,5 +1,23 @@
 define(['app/module'], function (module) {
 
+  /**
+   * @ngdoc controller
+   * @kind constructor
+   * @name askCtlr
+   * @description
+   * Controller for the ask root.layout.ask ui-router state, which
+   * provides an interface for asking a Samplestack question. Upon
+   * instantiation of the controller, an ssQnaDoc object is created
+   * for the new question and this object is attached to the $scope
+   * as $scope.qnaDoc.
+   *
+   * @param {angular.Scope} $scope (injected)
+   * @param {object} appRouting (injected)
+   * @param {object} ssQnaDoc The question model object.
+   *
+   * @property {Array.string} $scope.tagsInput An array of selected
+   * tag names.
+   */
   module.controller('askCtlr', [
 
     '$scope', 'appRouting', 'ssQnaDoc', 'ssTagsSearch',
@@ -54,6 +72,14 @@ define(['app/module'], function (module) {
         return tag;
       };
 
+      /**
+       * @ngdoc method
+       * @name askCtlr#$scope.save
+       * @description Posts the new question to the server if the question is
+       * valid, then redirects the user to the root.layout.qnaDoc view for
+       * that new question. If the question is invalid, an error message is
+       * displayed.
+       */
       $scope.save = function () {
 
         // convert tags-input data from array of objects to array of strings

--- a/browser/src/app/states/qnaDoc.js
+++ b/browser/src/app/states/qnaDoc.js
@@ -1,5 +1,38 @@
 define(['app/module'], function (module) {
 
+  /**
+   * @ngdoc controller
+   * @kind constructor
+   * @name qnaDocCtlr
+   * @description
+   * Controller for the ask root.layout.qnaDoc ui-router state, which
+   * displays a Samplestack question and its associated answers and
+   * comments. Upon instantiation of the controller, an ssQnaDoc for
+   * the question is created based on an ID parameter. The answers and
+   * comments are represented by ssAnswer and ssComment sub-objects
+   * of ssQnaDoc. The view also displays voting history information
+   * and authenticated users can cast votes and accept answers.
+   *
+   * @param {angular.Scope} $scope (injected)
+   * @param {object} $timeout (injected)
+   * @param {object} marked For parsing and displaying markdown content.
+   * @param {object} appRouting (injected)
+   * @param {object} ssQnaDoc Question model object.
+   * @param {object} ssAnswer Answer model object.
+   * @param {object} ssComment Comment model object.
+   * @param {object} ssVote Vote model object.
+   * @param {object} ssAcceptedAnswer Accepted answer model object.
+   *
+   * @property {boolean} $scope.setLoading Flag set to true when page
+   * data is loading.
+   * @property {ssQnaDoc} $scope.doc The document object to be displayed.
+   * @property {boolean} $scope.showQuestionComment Flag set to true
+   * when question comment form should be displayed.
+   * @property {Array.<object>} $scope.showAnswerComment Array of objects,
+   * one per answer, that determine whether to display an answer comment
+   * form.
+   * @property {object} $scope.draftAnswer A draft object for new answers.
+   */
   module.controller('qnaDocCtlr', [
 
     '$scope',
@@ -30,7 +63,8 @@ define(['app/module'], function (module) {
           { id: appRouting.params.id },
           // by passing a contributorId we instigate the getting
           // and availability of voting properties on the content
-          // objects
+          // objects [TODO Is this still relevant since /hasVoted
+          // endpoint is now gone?]
           $scope.store.session ? $scope.store.session.id : null
         );
         doc.$ml.waiting.then(
@@ -73,6 +107,7 @@ define(['app/module'], function (module) {
 
       };
 
+      // Handle search queries from the search bar
       $scope.$on('setQueryText', function (evt, arg) {
         appRouting.go('root.layout.explore.results', {
           q: $scope.dasherize(arg.queryText)
@@ -81,8 +116,10 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canVoteOn
-      * @description Returns whether current user can vote on the object
+      * @name qnaDocCtlr#$scope.canVoteOn
+      * @description Returns whether current user can vote on the object.
+      * Votes can be cast on questions and answers.
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.canVoteOn = function (obj) {
@@ -97,8 +134,9 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.hasVotedUp
+      * @name qnaDocCtlr#$scope.hasVotedUp
       * @description Returns whether current user has upvoted the object
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.hasVotedUp = function (obj) {
@@ -114,8 +152,9 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.hasVotedDown
+      * @name qnaDocCtlr#$scope.hasVotedDown
       * @description Returns whether current user has downvoted the object
+      * @param {object} obj A ssQnaDoc object or ssAnswer object
       * @returns {boolean} true or false
       */
       $scope.hasVotedDown = function (obj) {
@@ -159,7 +198,7 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canAcceptAnswer
+      * @name qnaDocCtlr#$scope.canAcceptAnswer
       * @description Returns whether current user can accept
       * an answer associated with the QnaDoc.
       * @param {ssAnswer} answer The ssAnswer object.
@@ -174,20 +213,35 @@ define(['app/module'], function (module) {
 
      /**
       * @ngdoc method
-      * @name $scope.canAnswer
+      * @name qnaDocCtlr#$scope.canAnswer
       * @description Returns whether current user can submit
       * an answer to the QnaDoc.
+      * @param {ssAnswer} answer The ssAnswer object.
       * @returns {boolean} true or false
       */
       $scope.canAnswer = function (answer) {
         return $scope.store.session;
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.answersCountLabel
+      * @description Returns a singular or plural answers label based on
+      * the number of answers.
+      * @returns {string} A label
+      */
       $scope.answersCountLabel = function () {
         var len = $scope.doc.answers.length;
         return len + (len === 1 ? ' Answer' : ' Answers');
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.marked
+      * @description Parses markdown-formatted text.
+      * @param {string} text Text to be parsed.
+      * @returns {string} Parsed text
+      */
       $scope.marked = function (text) {
         return marked(text);
       };
@@ -196,6 +250,12 @@ define(['app/module'], function (module) {
         appRouting.go('^.explore', { q: $scope.searchbarText });
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveAnswer
+      * @description Saves an answer if valid.
+      * @param {ssAnswer} answer Answer to be saved.
+      */
       $scope.saveAnswer = function (answer) {
         if (answer.$ml.valid) {
           answer.post().$ml.waiting.then(
@@ -217,6 +277,11 @@ define(['app/module'], function (module) {
         }
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveQuestionComment
+      * @description Saves a question comment if valid.
+      */
       $scope.saveQuestionComment = function () {
         var comment = $scope.doc.comments.draft;
         if (comment.$ml.valid) {
@@ -236,6 +301,11 @@ define(['app/module'], function (module) {
         }
       };
 
+     /**
+      * @ngdoc method
+      * @name qnaDocCtlr#$scope.saveAnswerComment
+      * @description Saves an answer comment if valid.
+      */
       $scope.saveAnswerComment = function (answer) {
         var comment = answer.comments.draft;
         if (comment.$ml.valid) {


### PR DESCRIPTION
Added documentation for the allTags, contributor, and login dialogs. Also for the ask and qnaDoc states.

NOTE: these changes are updates to JS comments only. (Adding comments to the HTML caused issues with the unit tests in a previous commit/PR https://github.com/marklogic/marklogic-samplestack/pull/556. Avoiding that here.)

This can replace https://github.com/marklogic/marklogic-samplestack/pull/556