### PR TITLE
Sauce ss local domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+addons:
+  hosts:
+    - samplestack.local
+
 # for non-pull-requests, aka pushes, requires secure emvironment
 # variables for access to MarkLogic nightlies (when applicable)
 # and for SauceLabs integration. These are configured in

--- a/browser/README.md
+++ b/browser/README.md
@@ -167,6 +167,9 @@ Note on `~@broken`: always specify this flag unless you are interested in seeing
 are known to be broken. Such tests are also flagged in the feature files with issue id numbers, so
 that they may be executed individually based on the issue that covers the problem.
 
+**Note: to use SauceLabs tests, please add a hosts file entry (or other domain resolution) that points "samplestack.local" to 127.0.0.1 on your machine.**
+The reasons for this are documented in https://support.saucelabs.com/entries/27401240-Testing-with-a-localhost-server-and-some-browsers-can-t-load-my-website .
+
 ## Node.js/npm Tips and Troubleshooting
 
 Please see [Node.js and npm Tips for Samplestack Development](https://github.com/marklogic/marklogic-samplestack/wiki/Node.js-and-npm-Tips-for-Samplestack-Development).

--- a/browser/dev-tasks/e2e/protractor.js
+++ b/browser/dev-tasks/e2e/protractor.js
@@ -37,6 +37,13 @@ var ptorConfig = {
 
 
 var go = function (args, cb) {
+  // sauce/IE doens't like "localhost", so we punt.
+  // running on Sauce now requires this hosts file entry
+  if (args.sauce) {
+    ptorConfig.baseUrl =
+    ptorConfig.baseUrl.replace('localhost', 'samplestack.local');
+  }
+
   if (args.tags) {
     ptorConfig.cucumberOpts.tags = [args.tags];
   }


### PR DESCRIPTION
This addresses #452.

SauceLabs uses a not-fully-reliable, slow proxy solution to work around
issues with testing remotely against localhost domain in Internet
Explorer (and Safari).

- Use 'samplestack.local' domain for Sauce-based e2e tests.
- Add this domain to hosts file in travis.
- Update readme with instruction.

BREAKING CHANGE: users will need to configure such a domain, typically
in their hosts file, to point to 127.0.0.1

(Note, this PR also includes one totally inconsequential docs change change that was missed in previous merge)

**Gaurav**: I have added the hosts file entry to engrlab-128-218 and tested -- it works.

I have put in an IT request to add it to rh6-intel64-80-qa-dev-2. It will also be need to be added to the Mac testing machine (and any machine on which people want to run tests with SauceLabs).

/cc @popzip 
