### PR TITLE
tag broken test with issue number and don't run by default

### DIFF
--- a/browser/dev-tasks/tasks/e2e.js
+++ b/browser/dev-tasks/tasks/e2e.js
@@ -22,6 +22,11 @@ var args = {
 
 _.merge(args, require('yargs').argv);
 
+if (~args.tags) {
+  // by default, do not execute known-broken tests
+  args.tags = '~@broken';
+}
+
 if (args.sauce && args.selenium !== 'external') {
   args.selenium = 'sauce';
 }

--- a/specs/features/as-mary/vote-on-question.feature
+++ b/specs/features/as-mary/vote-on-question.feature
@@ -6,7 +6,7 @@ Feature: Vote on Question
   gains reputation points. When a downvote is made to a  question, the author
   of the question loses reputation points.
 
-  @broken
+  @broken @564
   Scenario: Mary votes for Joe's question
     Given I am "Joe"
     When I visit the "ask" page


### PR DESCRIPTION
- add issue number to broken e2e test (#564)
- by default, exclude tests tagged as broken

Closes #563 

@gghai, ok to merge?