### PR TITLE
Path parsing issue in transform install, fixes #577

### DIFF
--- a/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicConfigureTask.groovy
+++ b/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicConfigureTask.groovy
@@ -97,8 +97,7 @@ public class MarkLogicConfigureTask extends MarkLogicTask {
 
     void putTransform(transform) {
         def transformFileName = transform.getPath().replaceAll(~"\\\\","/")
-        def transformName = transformFileName.replaceAll(~"\\.[^\\.]+", "").replaceAll(~".*\\/","")
-
+        def transformName = transformFileName.split("/")[-1].replaceAll(~"\\.[^\\.]+", "")
         if (transformName) {
             logger.info( "Saving transform " + transformName)
             RESTClient client = new RESTClient("http://" + config.marklogic.rest.host + ":" + config.marklogic.rest.port + "/v1/config/transforms/" + transformName)


### PR DESCRIPTION
This issue prevents installation of transforms when using the release artifact.  It is a critical hotfox for any user who's project path contains a '.'.

