### PR TITLE
Explicitly buffer download for dbload. Addresses issue #594

### DIFF
--- a/appserver/java-spring/build.gradle
+++ b/appserver/java-spring/build.gradle
@@ -19,7 +19,6 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath 'de.undercouch:gradle-download-task:1.2'
     }
 }
 
@@ -29,7 +28,6 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'spring-boot'
-apply plugin: 'de.undercouch.download'
 
 group = samplestackGroup
 version = samplestackVersion
@@ -82,15 +80,9 @@ assemble.dependsOn(dbInit, dbConfigure, test)
 /**
  * FETCH SEED DATA
  */
-task seedDataFetch {
-    def url = project.hasProperty("seedDataUrl") ? project.seedDataUrl : "http://developer.marklogic.com/media/gh/seed-data1.8.2.tgz"
-    logger.warn("Fetching data from " + url)
-    def destFile = file("${buildDir}/seed.tgz")
-    outputs.file destFile
-    download {
-       src url
-       dest destFile
-    }
+task seedDataFetch(type: MarkLogicFetchTask) {
+    url = project.hasProperty("seedDataUrl") ? project.seedDataUrl : "http://developer.marklogic.com/media/gh/seed-data1.8.2.tgz"
+    destFile = file("${buildDir}/seed.tgz")
 }
 seedDataFetch.dependsOn(processResources)
 

--- a/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicFetchTask.groovy
+++ b/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicFetchTask.groovy
@@ -2,18 +2,42 @@ import groovy.json.*
 import groovyx.net.http.RESTClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.Input
 
 public class MarkLogicFetchTask extends MarkLogicTask {
 
+    @Input
     String url
+
+    @OutputFile
     File destFile
 
     @TaskAction
     void fetchSeedData() {
         logger.warn("Fetching data from " + url)
         def is = new URL(url).openStream()
-        destFile << is
 
+        try {
+            OutputStream os = new FileOutputStream(destFile);
+            boolean finished = false;
+            try {
+                byte[] buf = new byte[1024 * 10];
+                int read;
+                while ((read = is.read(buf)) >= 0) {
+                    os.write(buf, 0, read);
+                }
+                os.flush();
+                finished = true;
+            } finally {
+                os.close();
+                if (!finished) {
+                    destFile.delete();
+                }
+            }
+        } finally {
+            is.close();
+        }
     }
 
 }


### PR DESCRIPTION
@laurelnaiad  let's see if this works for travis.  The dependencies are all solid -- seedDataFetch only runs after a clean.