### PR TITLE
browser: allow responses to DELETE calls to have data

### DIFF
--- a/appserver/java-spring/static/_marklogic/services/data/mlModelBase.js
+++ b/appserver/java-spring/static/_marklogic/services/data/mlModelBase.js
@@ -175,10 +175,7 @@ define(['_marklogic/module'], function (module) {
       };
 
       MlModel.prototype.onResponseDELETE = function (data) {
-        // we normally consider it an error if delete has a body
-        if (data && Object.keys(data).length) {
-          throw new Error('don\'nt assign data on DELETE');
-        }
+        // do nothing with responses to DELETE;
       };
 
       /**

--- a/browser/src/_marklogic/services/data/mlModelBase.js
+++ b/browser/src/_marklogic/services/data/mlModelBase.js
@@ -175,10 +175,7 @@ define(['_marklogic/module'], function (module) {
       };
 
       MlModel.prototype.onResponseDELETE = function (data) {
-        // we normally consider it an error if delete has a body
-        if (data && Object.keys(data).length) {
-          throw new Error('don\'nt assign data on DELETE');
-        }
+        // do nothing with responses to DELETE;
       };
 
       /**

--- a/browser/test/unit-tests/_marklogic/services/data/mlModelBase.unit.js
+++ b/browser/test/unit-tests/_marklogic/services/data/mlModelBase.unit.js
@@ -154,24 +154,7 @@ define(['testHelper'], function (helper) {
       });
 
       it(
-        'should throw an error if someone tries to do anything on DELETE',
-        function () {
-          var instance = impl1.create({
-            id: '1'
-          });
-          try {
-            instance.onHttpResponse({ stuff: 'bad'}, 'DELETE');
-          }
-          catch (err) {
-            assert(true);
-            return;
-          }
-          assert(false, 'no error was thrown');
-        }
-      );
-
-      it(
-        'should NOT throw an error if someone tries to do nothing on DELETE',
+        'should not error on DELETE',
         function () {
           var instance = impl1.create({
             id: '1'


### PR DESCRIPTION
If data are returned to an HTTP DELETE method, do not throw an error.

Closes #613