### PR TITLE
Search refinement

### DIFF
--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicQnAService.java
@@ -124,7 +124,11 @@ public class MarkLogicQnAService extends MarkLogicBaseService implements
 		ObjectNode query = (ObjectNode) mapper
 				.readValue("{\"search\":{\"qtext\":\"\"}}",
 						JsonNode.class);
-		this.rawSearch(SAMPLESTACK_CONTRIBUTOR, query, 1, DateTimeZone.forOffsetHours(1));
+		try {
+			this.rawSearch(SAMPLESTACK_CONTRIBUTOR, query, 1, DateTimeZone.forOffsetHours(1));
+		} catch (Exception e) {
+			logger.error("Cannot initialize application.  Something is probably wrong with the MarkLogic server.", e);
+		}
 	}
 	
 	/**

--- a/database/options/questions.json
+++ b/database/options/questions.json
@@ -1,5 +1,6 @@
 {
     "options": {
+        "additional-query": "<cts:json-property-range-query xmlns:cts=\"http://marklogic.com/cts\" operator=\">=\"><cts:property>voteCount</cts:property><cts:value xsi:type=\"xs:integer\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">-10000</cts:value><cts:option>score-function=linear</cts:option><cts:option>slope-factor=1</cts:option></cts:json-property-range-query>",
         "constraint": [
             {
                 "name": "askedBy",

--- a/database/options/questions.json
+++ b/database/options/questions.json
@@ -1,6 +1,6 @@
 {
     "options": {
-        "additional-query": "<cts:json-property-range-query xmlns:cts=\"http://marklogic.com/cts\" operator=\">=\"><cts:property>voteCount</cts:property><cts:value xsi:type=\"xs:integer\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">-10000</cts:value><cts:option>score-function=linear</cts:option><cts:option>slope-factor=1</cts:option></cts:json-property-range-query>",
+        "additional-query": "<cts:json-property-range-query xmlns:cts=\"http://marklogic.com/cts\" operator=\">=\"><cts:property>voteCount</cts:property><cts:value xsi:type=\"xs:integer\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">0</cts:value><cts:option>score-function=linear</cts:option><cts:option>slope-factor=1</cts:option></cts:json-property-range-query>",
         "constraint": [
             {
                 "name": "askedBy",


### PR DESCRIPTION
This commit changes the search options to address issue #572 .  It adds in a weighted query on voteCount that affects search rankings in the default search.

This commit shows that one can use additional-query to weight a default search result.  However, the weight and scale factor that is in use in this commit may not be optimal -- it works and demonstrably boosts questions with more votes.

Included are some screenshots of before and after this change.  To me, it seems to work...  

@gghai, do you think you'd like to look at this for evaluation?

Before:

![before-marklogic](https://cloud.githubusercontent.com/assets/382672/7010063/96398544-dc53-11e4-96bd-f45d970fd010.png)
![before-rest](https://cloud.githubusercontent.com/assets/382672/7010066/964c3aae-dc53-11e4-82b5-e93489948073.png)
![before-javascript](https://cloud.githubusercontent.com/assets/382672/7010067/96525e8e-dc53-11e4-82b0-e67517685727.png)
![before-java](https://cloud.githubusercontent.com/assets/382672/7010068/96561e8e-dc53-11e4-9741-08b3d5f7dc26.png)

After: 

![after-marklogic](https://cloud.githubusercontent.com/assets/382672/7010069/966b683e-dc53-11e4-9c76-cc40962c42e8.png)
![after-rest](https://cloud.githubusercontent.com/assets/382672/7010071/97e86144-dc53-11e4-9f01-679a73d3248b.png)
![after-javascript](https://cloud.githubusercontent.com/assets/382672/7010062/963306b0-dc53-11e4-9005-dbba7b5e72b2.png)
![after-java](https://cloud.githubusercontent.com/assets/382672/7010064/963a24f4-dc53-11e4-94f2-b8914a7b501d.png)







