### PR TITLE
node: when not "watching" gulp, keep middle-tier in-process

### DIFF
--- a/appserver/node-express/lib/master-process.js
+++ b/appserver/node-express/lib/master-process.js
@@ -129,5 +129,6 @@ var stop = function () {
 
 module.exports = {
   run: run,
-  stop: stop
+  stop: stop,
+  exit: function (cb) { stop(); cb(); }
 };

--- a/appserver/node-express/main.js
+++ b/appserver/node-express/main.js
@@ -14,4 +14,4 @@
  * limitations under the License. 
  */ 
 
-require('./lib/master-process').run();
+module.exports = require('./lib/master-process').run();

--- a/shared/js/dev-tasks/context.js
+++ b/shared/js/dev-tasks/context.js
@@ -312,10 +312,17 @@ self = module.exports = {
   // on port 8090?
   startServer: function (filePath, port, html5) {
     if (port === '3000') {
-      var middleProcess = childProcess.fork(
-        path.join(serverBuilds.built, 'main')
-      );
-      self.setActiveServer(port, middleProcess);
+      if (this.watchTaskCalled) {
+        var middleProcess = childProcess.fork(
+          path.join(serverBuilds.built, 'main')
+        );
+        self.setActiveServer(port, middleProcess);
+      }
+      else {
+        self.setActiveServer(
+          port, require(path.join(serverRootDir, 'main'))
+        );
+      }
     }
     else {
       // console.log('don\'t start middle tier -- ' + port);


### PR DESCRIPTION
If the application isn't launch using `gulp watch`, then don't use a
separate process to run the middle tier.

Allows for straightforward debugging of the middle tier.

Closes #638