### PR TITLE
browser: widen related-tags popup to avoid line breaks

### DIFF
--- a/appserver/java-spring/static/app/styles/style.css
+++ b/appserver/java-spring/static/app/styles/style.css
@@ -6091,7 +6091,7 @@ ss-related-tags {
   position: absolute;
   right: -160px;
   top: -2px;
-  width: 165px;
+  width: 169px;
   border: solid 1px #ddd;
   border-radius: 5px;
   background-color: #fff;
@@ -6119,7 +6119,7 @@ ss-related-tags {
     overflow-y: scroll;
     min-height: 65px;
     max-height: 143px;
-    width: 165px;
+    width: 169px;
     right: -1px; }
   ss-related-tags .ss-related-body div {
     width: 100%;

--- a/browser/src/app/styles/directives/_ss-related-tags.scss
+++ b/browser/src/app/styles/directives/_ss-related-tags.scss
@@ -3,7 +3,7 @@ ss-related-tags {
   position: absolute;
   right: -160px;
   top: -2px;
-  width: 165px;
+  width: 169px;
   border: solid 1px #ddd;
   border-radius: 5px;
   background-color: #fff;
@@ -36,7 +36,7 @@ ss-related-tags {
     overflow-y:scroll;
     min-height: 65px;
     max-height: 143px;
-    width: 165px;
+    width: 169px;
     right: -1px;
   }
 


### PR DESCRIPTION
Increased width of related-tags popup from 165px to 169px to avoid line breaks in Windows Chrome and Windows FF browsers.

Closes #640