### PR TITLE
browser: in all tags dialog, reset to first page on clear text

### DIFF
--- a/appserver/java-spring/static/app/dialogs/allTags.html
+++ b/appserver/java-spring/static/app/dialogs/allTags.html
@@ -40,7 +40,7 @@
         >
           <i
             class="glyphicon glyphicon-remove"
-            ng-click="selected = null"
+            ng-click="clearText()"
           ></i>
         </div>
         <div class="tags-modal-search-icon">

--- a/appserver/java-spring/static/app/dialogs/allTags.js
+++ b/appserver/java-spring/static/app/dialogs/allTags.js
@@ -191,6 +191,18 @@ define(['app/module'], function (module) {
 
       /**
        * @ngdoc method
+       * @name allTagsDialogCtlr#$scope.clearText
+       * @description
+       * Clears text input and resets dialog.
+       */
+      $scope.clearText = function () {
+        $scope.selected = '';
+        $scope.currentPage = 1; // reset to first page
+        search();
+      };
+
+      /**
+       * @ngdoc method
        * @name allTagsDialogCtlr#$scope.search
        * @description
        * Performs a search for tags based on page and sort criteria.

--- a/browser/src/app/dialogs/allTags.html
+++ b/browser/src/app/dialogs/allTags.html
@@ -40,7 +40,7 @@
         >
           <i
             class="glyphicon glyphicon-remove"
-            ng-click="selected = null"
+            ng-click="clearText()"
           ></i>
         </div>
         <div class="tags-modal-search-icon">

--- a/browser/src/app/dialogs/allTags.js
+++ b/browser/src/app/dialogs/allTags.js
@@ -191,6 +191,18 @@ define(['app/module'], function (module) {
 
       /**
        * @ngdoc method
+       * @name allTagsDialogCtlr#$scope.clearText
+       * @description
+       * Clears text input and resets search.
+       */
+      $scope.clearText = function () {
+        $scope.selected = '';
+        $scope.currentPage = 1; // reset to first page
+        search();
+      };
+
+      /**
+       * @ngdoc method
        * @name allTagsDialogCtlr#$scope.search
        * @description
        * Performs a search for tags based on page and sort criteria.


### PR DESCRIPTION
When the clear-text button is clicked in the all-tags filter input box:

- reset all-tags dialog pagination to the first page
- clear the all-tags input box
- initiate a new search (to reset tag content in all-tags dialog)

Closes #518