### PR TITLE
browser: make a deep copy of criteria when getting related tags

### DIFF
--- a/appserver/java-spring/static/app/directives/ssRelatedTags.js
+++ b/appserver/java-spring/static/app/directives/ssRelatedTags.js
@@ -49,7 +49,7 @@ define([
 
           // Remove any tag constraint values, we don't want those
           // influencing frequencies in realted-tags results
-          var newCriteria = _.clone(scope.criteria);
+          var newCriteria = angular.copy(scope.criteria);
           if (newCriteria.constraints && newCriteria.constraints.tags) {
             newCriteria.constraints.tags.values = null;
           }

--- a/browser/src/app/directives/ssRelatedTags.js
+++ b/browser/src/app/directives/ssRelatedTags.js
@@ -49,7 +49,7 @@ define([
 
           // Remove any tag constraint values, we don't want those
           // influencing frequencies in realted-tags results
-          var newCriteria = _.clone(scope.criteria);
+          var newCriteria = angular.copy(scope.criteria);
           if (newCriteria.constraints && newCriteria.constraints.tags) {
             newCriteria.constraints.tags.values = null;
           }


### PR DESCRIPTION
_.clone was copying property objects by reference. Needed to do a deep copy with angular.copy.
A deep copy means the original search criteria isn't changed when we modify its copy for retrieving related tags.

Closes #653