### PR TITLE
MarkLogic 9 compatibility

### DIFF
--- a/database/transforms/search-response.sjs
+++ b/database/transforms/search-response.sjs
@@ -69,7 +69,7 @@ function searchTransform(context, params, input) {
         outputObject.owner = unknownOwner;
     };
     var ownerNodes = input.xpath(".//owner");
-    if (ownerNodes.count > 0) {
+    if (fn.count(ownerNodes) > 0) {
         var joinedOwners = joinReputations(ownerNodes);
         outputObject.owner = joinedOwners[outputObject.owner.id];
         if (outputObject.answers !== undefined) {
@@ -95,7 +95,7 @@ function searchTransform(context, params, input) {
                 var result = results[i];
                 var matches = result.matches;
                 var uri = result.uri;
-                var sourceDoc = fn.doc(uri).next().value;
+                var sourceDoc = cts.doc(uri);
                 for (var j = 0; j < matches.length; j++) {
                     var match = matches[j];
                     var source = "";
@@ -126,7 +126,7 @@ function searchTransform(context, params, input) {
                         }
                         var answerNodePath = "/array-node(\"answers\")/object-node()[" + answerIndex + "]/id";
 
-                        var answersSource = sourceDoc.xpath(answerNodePath).next().value;
+                        var answersSource = fn.head(sourceDoc.xpath(answerNodePath));
                         if (answersSource !== undefined) {
                             match.id = answersSource;
                         } else {


### PR DESCRIPTION
- migrates from the old `ValueIterator` to `Sequence`
- simplifies search result matches resolution

With this, the `gradle dbTest` target was succeeding against MarkLogic 9.0.1.

Please also see #714 which contains fixes to the Node.js setup in general and for the Travis build.